### PR TITLE
Corrected a typo about subscript

### DIFF
--- a/csl-json/markup.rst
+++ b/csl-json/markup.rst
@@ -69,7 +69,7 @@ Note that tags must be JSON-encoded in the input object::
 **<sup>superscript</sup>**
   Set the enclosed text in |superscript| form.
 
-**<sup>superscript</sup>**
+**<sub>subscript</sub>**
   Set the enclosed text in |subscript| form.
 
 **<span class="nocase">superscript</span>**


### PR DESCRIPTION
The heading for <subscript> information was identical to the superscript heading. Now, it is corrected.
