### PR TITLE
Fix typo and incorrect code span

### DIFF
--- a/csl-m/index.rst
+++ b/csl-m/index.rst
@@ -847,7 +847,7 @@ style, the ``leading-noise-words`` attribute takes a comma-delimited
 list of words as its argument.
 
 When a list is set, the same attribute on a ``cs:text`` node with
-``variable="title" takes an argument of ``demote`` or ``drop``.  With
+``variable="title"`` takes an argument of ``demote`` or ``drop``.  With
 the ``demote`` attribute, noise words at the start of the field are
 rendered after the remainder of the title field, delimited by a comma.
 With the ``drop`` attribute the leading noise words are simply
@@ -975,7 +975,7 @@ value should be a comma-delimited list of words or phrases.
 
 .. sourcecode:: xml
 
-   <style-options skip-list="a,an,the,or,and,over,under"/>
+   <style-options skip-words="a,an,the,or,and,over,under"/>
 
 ====================================================================================
 ``subgroup-delimiter``,  ``subgroup-delimiter-precedes-last``, ``and`` |(extension)|


### PR DESCRIPTION
A bit of code was missing a closing tag, and it said `skip-list` instead of `skip-words`.